### PR TITLE
Updating PR workflow to fix team lookup issue

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -9,9 +9,11 @@ jobs:
     name: Reject Unauthorized PRs
 
     steps:
-      - name: Reject if submitter is not collaborator
+      - name: Get collaborator status
+        id: get-collaborator-status
         uses: actions/github-script@v5
         with:
+         github-token: ${{ secrets.GH_PUBLICREPO_ORGREAD_TOKEN }}
          script: |
           var isVerifiedCollaborator = false
           try {
@@ -19,7 +21,7 @@ jobs:
             core.info(`Performing GET on '${collaboratorUrl}'`)
             var response = await github.request(`GET ${collaboratorUrl}`, {
              headers: {
-              "Authorization" : "token ${{ secrets.GITHUB_TOKEN }}"
+              "Authorization" : "token ${{ secrets.GH_PUBLICREPO_ORGREAD_TOKEN }}"
              }
             })
             
@@ -31,10 +33,19 @@ jobs:
              core.debug(`Collaborator request returned status code: '${err.status}'`)
             } else {
              // No status code was returned...
+             core.setOutput('isVerifiedCollaborator', false);
              core.setFailed(`Encountered error during collaborator status check: ${err}`)
             }
           }
           
+          core.setOutput('isVerifiedCollaborator', isVerifiedCollaborator);
+          
+      - name: Reject if submitter is not collaborator
+        uses: actions/github-script@v5
+        with:
+         isVerifiedCollaborator: ${{ steps.get-collaborator-status.outputs.isVerifiedCollaborator }}
+         script: |
+          var isVerifiedCollaborator = core.getBooleanInput('isVerifiedCollaborator');
           if (!isVerifiedCollaborator) {
           
                github.rest.issues.createComment({
@@ -69,5 +80,3 @@ jobs:
 
               core.info("${{ github.actor }} is validated as a collaborator!")
           }
-          
-    


### PR DESCRIPTION
The default token used for github actions does not have access to read team memberships, which means for users that are added as collaborators via a team, we couldn't resolve whether or not they were collaborators using the default token. To address this, this change breaks our workflow into two steps, the first will get the collaborator status using a new token with org read access, and the second step will perform the associated PR actions (commenting, tagging, closing, etc).